### PR TITLE
Fix/EBS snapshot multiple prices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Build artifacts
 /build
 

--- a/internal/terraform/aws/ebs_snapshot.go
+++ b/internal/terraform/aws/ebs_snapshot.go
@@ -18,7 +18,7 @@ func NewEbsSnapshotGB(name string, resource *EbsSnapshot) *EbsSnapshotGB {
 	c.defaultFilters = []base.Filter{
 		{Key: "servicecode", Value: "AmazonEC2"},
 		{Key: "productFamily", Value: "Storage Snapshot"},
-		{Key: "usagetype", Value: "/EBS:SnapshotUsage/", Operation: "REGEX"},
+		{Key: "usagetype", Value: "/EBS:SnapshotUsage$/", Operation: "REGEX"},
 	}
 
 	return c

--- a/internal/terraform/aws/ebs_snapshot_copy.go
+++ b/internal/terraform/aws/ebs_snapshot_copy.go
@@ -18,7 +18,7 @@ func NewEbsSnapshotCopyGB(name string, resource *EbsSnapshotCopy) *EbsSnapshotCo
 	c.defaultFilters = []base.Filter{
 		{Key: "servicecode", Value: "AmazonEC2"},
 		{Key: "productFamily", Value: "Storage Snapshot"},
-		{Key: "usagetype", Value: "/EBS:SnapshotUsage/", Operation: "REGEX"},
+		{Key: "usagetype", Value: "/EBS:SnapshotUsage$/", Operation: "REGEX"},
 	}
 
 	return c


### PR DESCRIPTION
We were matching for both `EBS:SnapshotUsageUnderBilling` and `EBS:SnapshotUsage` usages. This changes so we only match for usages ending with `EBS:SnapshotUsage`.