### PR TITLE
Add `--no-color` and sort output to simplify diffs

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -15,10 +15,11 @@ import (
 )
 
 func main() {
-	log.SetFormatter(&log.TextFormatter{
+	formatter := &log.TextFormatter{
 		DisableTimestamp:       true,
 		DisableLevelTruncation: true,
-	})
+	}
+	log.SetFormatter(formatter)
 
 	app := &cli.App{
 		Name:                 "infracost",
@@ -52,6 +53,11 @@ func main() {
 				Usage:   "Output (json|table)",
 				Value:   "table",
 			},
+			&cli.BoolFlag{
+				Name:  "no-color",
+				Usage: "Turn off colored output",
+				Value: false,
+			},
 			&cli.StringFlag{
 				Name:  "api-url",
 				Usage: "Price List API URL",
@@ -65,6 +71,12 @@ func main() {
 		},
 		Action: func(c *cli.Context) error {
 			var planJSON []byte
+
+			if c.Bool("no-color") {
+				config.Config.NoColor = true
+				formatter.DisableColors = true
+				color.NoColor = true
+			}
 
 			logLevel := log.InfoLevel
 			if c.Bool("verbose") {

--- a/internal/terraform/aws/base.go
+++ b/internal/terraform/aws/base.go
@@ -1,9 +1,9 @@
 package aws
 
 import (
-	"infracost/pkg/base"
-
 	"github.com/shopspring/decimal"
+	"infracost/pkg/base"
+	"sort"
 )
 
 var DefaultVolumeSize = 8
@@ -141,10 +141,16 @@ func (r *BaseAwsResource) RawValues() map[string]interface{} {
 }
 
 func (r *BaseAwsResource) SubResources() []base.Resource {
+	sort.Slice(r.subResources, func(i, j int) bool {
+		return r.subResources[i].Address() < r.subResources[j].Address()
+	})
 	return r.subResources
 }
 
 func (r *BaseAwsResource) PriceComponents() []base.PriceComponent {
+	sort.Slice(r.priceComponents, func(i, j int) bool {
+		return r.priceComponents[i].Name() < r.priceComponents[j].Name()
+	})
 	return r.priceComponents
 }
 

--- a/pkg/base/costs.go
+++ b/pkg/base/costs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"sort"
 )
 
 var HoursInMonth = 730
@@ -108,6 +109,10 @@ func GenerateCostBreakdowns(q QueryRunner, resources []Resource) ([]ResourceCost
 		}
 		costBreakdowns = append(costBreakdowns, getCostBreakdown(resource, results[&resource]))
 	}
+
+	sort.Slice(costBreakdowns, func(i, j int) bool {
+		return costBreakdowns[i].Resource.Address() < costBreakdowns[j].Resource.Address()
+	})
 
 	return costBreakdowns, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,8 +11,9 @@ import (
 
 // ConfigSpec contains mapping of environment variable names to config values
 type ConfigSpec struct {
-	Logger *logrus.Logger
-	ApiUrl string `envconfig:"INFRACOST_API_URL"  required:"true"  default:"https://aws-prices-graphql.alistair.scot"`
+	Logger  *logrus.Logger
+	NoColor bool
+	ApiUrl  string `envconfig:"INFRACOST_API_URL"  required:"true"  default:"https://aws-prices-graphql.alistair.scot"`
 }
 
 func (c *ConfigSpec) SetLogger(logger *logrus.Logger) {
@@ -31,6 +32,8 @@ func fileExists(path string) bool {
 func loadConfig() *ConfigSpec {
 	var config ConfigSpec
 	var err error
+
+	config.NoColor = false
 
 	if fileExists(".env.local") {
 		err = godotenv.Load(".env.local")

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"infracost/pkg/base"
 	"strings"
+
+	"infracost/pkg/base"
+	"infracost/pkg/config"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/shopspring/decimal"
@@ -50,6 +52,15 @@ func ToTable(resourceCostBreakdowns []base.ResourceCostBreakdown) ([]byte, error
 	overallTotalHourly := decimal.Zero
 	overallTotalMonthly := decimal.Zero
 
+	color := []tablewriter.Colors{
+		tablewriter.Colors{tablewriter.FgHiBlackColor},
+		tablewriter.Colors{tablewriter.FgHiBlackColor},
+		tablewriter.Colors{tablewriter.FgHiBlackColor},
+	}
+	if config.Config.NoColor {
+		color = nil
+	}
+
 	for _, breakdown := range resourceCostBreakdowns {
 		table.Append([]string{breakdown.Resource.Address(), "", ""})
 
@@ -69,11 +80,7 @@ func ToTable(resourceCostBreakdowns []base.ResourceCostBreakdown) ([]byte, error
 				formatDecimal(priceComponentCost.HourlyCost, "%.4f"),
 				formatDecimal(priceComponentCost.MonthlyCost, "%.4f"),
 			}
-			table.Rich(row, []tablewriter.Colors{
-				tablewriter.Colors{tablewriter.FgHiBlackColor},
-				tablewriter.Colors{tablewriter.FgHiBlackColor},
-				tablewriter.Colors{tablewriter.FgHiBlackColor},
-			})
+			table.Rich(row, color)
 		}
 
 		for _, subResourceBreakdown := range breakdown.SubResourceCosts {
@@ -93,11 +100,7 @@ func ToTable(resourceCostBreakdowns []base.ResourceCostBreakdown) ([]byte, error
 					formatDecimal(priceComponentCost.HourlyCost, "%.4f"),
 					formatDecimal(priceComponentCost.MonthlyCost, "%.4f"),
 				}
-				table.Rich(row, []tablewriter.Colors{
-					tablewriter.Colors{tablewriter.FgHiBlackColor},
-					tablewriter.Colors{tablewriter.FgHiBlackColor},
-					tablewriter.Colors{tablewriter.FgHiBlackColor},
-				})
+				table.Rich(row, color)
 			}
 		}
 

--- a/pkg/parsers/terraform/terraform.go
+++ b/pkg/parsers/terraform/terraform.go
@@ -12,6 +12,7 @@ import (
 
 	"infracost/internal/terraform/aws"
 	"infracost/pkg/base"
+	"infracost/pkg/config"
 
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
@@ -73,7 +74,11 @@ func terraformCommand(options *TerraformOptions, args ...string) ([]byte, error)
 	}
 
 	cmd := exec.Command(terraformBinary, args...)
-	log.Info(color.HiGreenString("Running command: %s", cmd.String()))
+	if config.Config.NoColor {
+		log.Infof("Running command: %s", cmd.String())
+	} else {
+		log.Info(color.HiGreenString("Running command: %s", cmd.String()))
+	}
 	cmd.Dir = options.TerraformDir
 
 	var outbuf bytes.Buffer


### PR DESCRIPTION
Both of these changes simplify `git diff` being used to compare infracost outputs.
The sorting is done based on `Resource.Address` (e.g. `aws_autoscaling_group.lt1` then `aws_elb.elb1`). Within each resource;
- the `PriceComponentCosts` are sorted by `Name` (e.g. `GB` then `Instance hours`)
- the sub-resources are sorted by `Address` (similar to top-level resources)

Alphabetical sorting works better than numerical sorting based on hourly/monthly cost since the costs might change across infracost runs for the same resource thus making it harder to `git diff` the output.