### PR TITLE
Prevent a division by zero error on launch template quantity

### DIFF
--- a/internal/terraform/aws/ec2_launch_template.go
+++ b/internal/terraform/aws/ec2_launch_template.go
@@ -19,6 +19,9 @@ func ec2LaunchTemplateHoursQuantityFactory(r resource.Resource, purchaseOption s
 		if purchaseOption == "spot" {
 			purchaseOptionCount = spotCount
 		}
+		if purchaseOptionCount == 0 || r.ResourceCount() == 0 {
+			return decimal.NewFromInt(0)
+		}
 		return decimal.NewFromInt(int64(purchaseOptionCount)).Div(decimal.NewFromInt(int64(r.ResourceCount())))
 	}
 }


### PR DESCRIPTION
When my launch template ```desired_capacity``` is set to ```0``` I get a division by zero error.
```hcl-terraform
resource "aws_autoscaling_group" "demo" {
  availability_zones = ["eu-west-2a","eu-west-2b","eu-west-2c"]
  desired_capacity   = 0
  max_size           = 1
  min_size           = 0

  launch_template {
    id      = aws_launch_template.demo.id
    version = "$Latest"
  }
}
```
Running the program results in the following stack trace in release ```0.4.0```.
```
panic: decimal division by 0

goroutine 1 [running]:
github.com/shopspring/decimal.Decimal.QuoRem(0xc00006d390, 0x0, 0xc00006d370, 0x0, 0xc000000010, 0x100e0d6, 0xc0002764e0, 0x20, 0x20)
        /Users/ali/go/pkg/mod/github.com/shopspring/decimal@v1.2.0/decimal.go:500 +0x375
github.com/shopspring/decimal.Decimal.DivRound(0xc00006d390, 0x0, 0xc00006d370, 0x0, 0xc000000010, 0xc0002800d0, 0xc00006d368)
        /Users/ali/go/pkg/mod/github.com/shopspring/decimal@v1.2.0/decimal.go:542 +0x6e
github.com/shopspring/decimal.Decimal.Div(...)
        /Users/ali/go/pkg/mod/github.com/shopspring/decimal@v1.2.0/decimal.go:487
infracost/internal/terraform/aws.ec2LaunchTemplateHoursQuantityFactory.func1(0x1519e80, 0xc00005d920, 0xc00006d440, 0x97)
        /Users/ali/code/infracost/internal/terraform/aws/ec2_launch_template.go:22 +0x1c3
infracost/pkg/resource.(*BasePriceComponent).Quantity(0xc0001447e0, 0xc000000000, 0xc000120440)
        /Users/ali/code/infracost/pkg/resource/resource.go:131 +0x254
infracost/pkg/resource.(*BasePriceComponent).HourlyCost(0xc0001447e0, 0xc00006d518, 0x1003df3)
        /Users/ali/code/infracost/pkg/resource/resource.go:154 +0xec
infracost/pkg/costs.createPriceComponentCost(0x15194e0, 0xc0001447e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/ali/code/infracost/pkg/costs/breakdown.go:38 +0x64
infracost/pkg/costs.getCostBreakdown(0x1519e80, 0xc00005d920, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/ali/code/infracost/pkg/costs/breakdown.go:67 +0x251
infracost/pkg/costs.getCostBreakdown(0x1519e00, 0xc00000e540, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/ali/code/infracost/pkg/costs/breakdown.go:72 +0x40e
infracost/pkg/costs.GenerateCostBreakdowns(0x150ea00, 0xc0002cc870, 0xc000220000, 0x3, 0x3, 0xc00001a420, 0x24, 0x0, 0x18, 0xc000120ec0)
        /Users/ali/code/infracost/pkg/costs/breakdown.go:107 +0x2ef
main.main.func2(0xc000146a80, 0xc000120e00, 0xe)
        /Users/ali/code/infracost/cmd/infracost/main.go:129 +0x389
github.com/urfave/cli/v2.(*App).RunContext(0xc000104480, 0x1516220, 0xc00012c008, 0xc000112180, 0x3, 0x3, 0x0, 0x0)
        /Users/ali/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:315 +0x70b
github.com/urfave/cli/v2.(*App).Run(...)
        /Users/ali/go/pkg/mod/github.com/urfave/cli/v2@v2.2.0/app.go:215
main.main()
        /Users/ali/code/infracost/cmd/infracost/main.go:153 +0x4fb
```

After compiling with the fix it runs without error which is correct for my infrastructure.
```
NAME                                                   QUANTITY  UNIT      HOURLY COST  MONTHLY COST  

  aws_autoscaling_group.demo                                                 
  ├─ aws_launch_template.demo instance hours (t2.micro)         0  hour           0.0000        0.0000  
  └─ aws_launch_template.demo.root_block_device GB              0  GB/month       0.0000        0.0000  
  Total                                                                           0.0000        0.0000 
```