### PR TITLE
Fix, what looks like, a typo

### DIFF
--- a/internal/terraform/aws/rds_instance.go
+++ b/internal/terraform/aws/rds_instance.go
@@ -64,7 +64,7 @@ func NewRdsInstance(address string, region string, rawValues map[string]interfac
 	case "oracle-se1":
 		databaseEdition = "Standard One"
 	case "oracle-se2":
-		databaseEdition = "Standard 2"
+		databaseEdition = "Standard Two"
 	case "oracle-ee", "sqlserver-ee":
 		databaseEdition = "Enterprise"
 	case "sqlserver-ex":


### PR DESCRIPTION
Example resource that was not matching a price before this commit:
```
resource "aws_db_instance" "issue1” {
  allocated_storage    = 20
  engine               = "oracle-se2"
  instance_class       = "db.r5.2xlarge"
}
```

This might have caused https://github.com/aliscott/cloud-pricing-api/issues/2, I'll ask the issue creator to confirm.