### PR TITLE
Make postgres engine match API spec

### DIFF
--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -143,13 +143,13 @@ resource "aws_db_instance" "db_mysql" {
 
 resource "aws_db_instance" "db_postgresql" {
   allocated_storage    = 20
-  engine               = "PostgreSQL"
+  engine               = "postgres"
   instance_class       = "db.t2.small"
 }
 
 resource "aws_db_instance" "db_postgresql_iops" {
   allocated_storage    = 20
-  engine               = "PostgreSQL"
+  engine               = "postgres"
   instance_class       = "db.t2.small"
   storage_type         = "io1"
   iops                 = 400

--- a/internal/terraform/aws/rds_instance.go
+++ b/internal/terraform/aws/rds_instance.go
@@ -41,7 +41,7 @@ func NewRdsInstance(address string, region string, rawValues map[string]interfac
 
 	var databaseEngine string
 	switch rawValues["engine"].(string) {
-	case "postgresql":
+	case "postgres":
 		databaseEngine = "PostgreSQL"
 	case "mysql":
 		databaseEngine = "MySQL"


### PR DESCRIPTION
AWS has the engine listed as postgres instead of postgresql: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

This resolves https://github.com/aliscott/cloud-pricing-api/issues/2#issuecomment-677532438