### PR TITLE
AWS Lambdas and Price Range concept

### DIFF
--- a/internal/terraform/aws/lambda.go
+++ b/internal/terraform/aws/lambda.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"infracost/pkg/resource"
+
+	"github.com/shopspring/decimal"
+)
+
+func NewLambdaFunction(address string, region string, rawValues map[string]interface{}) resource.Resource {
+	r := resource.NewBaseResource(address, rawValues, true)
+
+	costPerReq := decimal.NewFromFloat(0.2 / 1000000)
+
+	// From attached aws_cloudwatch_event_rule
+	// schedule_expression = "rate(1 minute)"
+	// Can calculate the rate of requests
+
+	timeoutSec := decimal.NewFromFloat(rawValues["timeout"].(float64))
+	maxRequestsPerHour := decimal.NewFromInt(60 * 60).Div(timeoutSec)
+
+	hoursProductFilter := &resource.ProductFilter{
+		VendorName:    strPtr("aws"),
+		Region:        strPtr(region),
+		Service:       strPtr("AWS Lambda"),
+		ProductFamily: strPtr("Lambda"),
+	}
+	priceRange := resource.NewBasePriceRangeComponent("Requests", r, "request", "hour", hoursProductFilter, nil)
+
+	// Completely unbounded example
+	// The function can never be triggered or the function can run constantly with a the given timeout (3 sec)
+	priceRange.SetPriceRange(&resource.PriceRange{
+		Min: decimal.NewFromInt(0).Mul(costPerReq),
+		Max: maxRequestsPerHour.Mul(costPerReq),
+	})
+	r.AddPriceRangeComponent(priceRange)
+
+	return r
+}

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getLineItemCount(breakdown costs.ResourceCostBreakdown) int {
-	count := len(breakdown.PriceComponentCosts)
+	count := len(breakdown.PriceComponentCosts) + len(breakdown.PriceRangeComponentCosts)
 
 	for _, subResourceBreakdown := range flattenSubResourceBreakdowns(breakdown.SubResourceCosts) {
 		count += len(subResourceBreakdown.PriceComponentCosts)
@@ -100,6 +100,25 @@ func ToTable(resourceCostBreakdowns []costs.ResourceCostBreakdown) ([]byte, erro
 				priceComponentCost.PriceComponent.Unit(),
 				formatDecimal(priceComponentCost.HourlyCost, "%.4f"),
 				formatDecimal(priceComponentCost.MonthlyCost, "%.4f"),
+			}
+			table.Rich(row, color)
+		}
+
+		for _, priceRangeComponentCost := range breakdown.PriceRangeComponentCosts {
+			lineItem++
+
+			maxHourly := formatDecimal(priceRangeComponentCost.MaxHourlyCost, "%.4f")
+			minHourly := formatDecimal(priceRangeComponentCost.MinHourlyCost, "%.4f")
+
+			maxMonthly := formatDecimal(priceRangeComponentCost.MaxMonthlyCost, "%.4f")
+			minMonthly := formatDecimal(priceRangeComponentCost.MinMonthlyCost, "%.4f")
+
+			row := []string{
+				fmt.Sprintf("%s %s", getTreePrefix(lineItem, lineItemCount), priceRangeComponentCost.PriceComponent.Name()),
+				formatQuantity(priceRangeComponentCost.PriceComponent.Quantity()),
+				priceRangeComponentCost.PriceComponent.Unit(),
+				fmt.Sprintf("%s - %s", minHourly, maxHourly),
+				fmt.Sprintf("%s - %s", minMonthly, maxMonthly),
 			}
 			table.Rich(row, color)
 		}

--- a/pkg/parsers/terraform/terraform.go
+++ b/pkg/parsers/terraform/terraform.go
@@ -59,6 +59,8 @@ func createResource(resourceType string, address string, rawValues map[string]in
 		return aws.NewElb(address, awsRegion, rawValues, false)
 	case "aws_nat_gateway": // alias for aws_lb
 		return aws.NewNatGateway(address, awsRegion, rawValues)
+	case "aws_lambda_function":
+		return aws.NewLambdaFunction(address, awsRegion, rawValues)
 	}
 	return nil
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -49,13 +49,26 @@ type PriceComponent interface {
 	HourlyCost() decimal.Decimal
 }
 
+type PriceRangeComponent interface {
+	Name() string
+	Unit() string
+	ProductFilter() *ProductFilter
+	PriceFilter() *PriceFilter
+	Quantity() decimal.Decimal
+	PriceRange() *PriceRange
+	SetPriceRange(priceRange *PriceRange)
+	HourlyCost() *PriceRange
+}
+
 type Resource interface {
 	Address() string
 	RawValues() map[string]interface{}
 	SubResources() []Resource
 	AddSubResource(Resource)
 	PriceComponents() []PriceComponent
+	PriceRangeComponents() []PriceRangeComponent
 	AddPriceComponent(PriceComponent)
+	AddPriceRangeComponent(PriceRangeComponent)
 	References() map[string]Resource
 	AddReference(name string, resource Resource)
 	ResourceCount() int
@@ -90,6 +103,22 @@ type BasePriceComponent struct {
 	price                  decimal.Decimal
 }
 
+type PriceRange struct {
+	Max decimal.Decimal
+	Min decimal.Decimal
+}
+
+type BasePriceRangeComponent struct {
+	name                   string
+	resource               Resource
+	timeUnit               string
+	unit                   string
+	productFilter          *ProductFilter
+	priceFilter            *PriceFilter
+	quantityMultiplierFunc func(resource Resource) decimal.Decimal
+	priceRange             *PriceRange
+}
+
 func NewBasePriceComponent(name string, resource Resource, unit string, timeUnit string, productFilter *ProductFilter, priceFilter *PriceFilter) *BasePriceComponent {
 	return &BasePriceComponent{
 		name:          name,
@@ -99,6 +128,23 @@ func NewBasePriceComponent(name string, resource Resource, unit string, timeUnit
 		productFilter: productFilter,
 		priceFilter:   priceFilter,
 		price:         decimal.Zero,
+	}
+}
+
+func NewBasePriceRangeComponent(name string, resource Resource, unit string, timeUnit string, productFilter *ProductFilter, priceFilter *PriceFilter) *BasePriceRangeComponent {
+	priceRange := &PriceRange{
+		Max: decimal.Zero,
+		Min: decimal.Zero,
+	}
+
+	return &BasePriceRangeComponent{
+		name:          name,
+		resource:      resource,
+		timeUnit:      timeUnit,
+		unit:          unit,
+		productFilter: productFilter,
+		priceFilter:   priceFilter,
+		priceRange:    priceRange,
 	}
 }
 
@@ -154,14 +200,67 @@ func (c *BasePriceComponent) HourlyCost() decimal.Decimal {
 	return c.price.Mul(c.Quantity()).Div(monthToHourDivisor)
 }
 
+func (c *BasePriceRangeComponent) Name() string {
+	return c.name
+}
+
+func (c *BasePriceRangeComponent) Unit() string {
+	return c.unit
+}
+func (c *BasePriceRangeComponent) ProductFilter() *ProductFilter {
+	return c.productFilter
+}
+
+func (c *BasePriceRangeComponent) PriceFilter() *PriceFilter {
+	return c.priceFilter
+}
+
+func (c *BasePriceRangeComponent) SetProductFilter(productFilter *ProductFilter) {
+	c.productFilter = productFilter
+}
+
+func (c *BasePriceRangeComponent) SetPriceFilter(priceFilter *PriceFilter) {
+	c.priceFilter = priceFilter
+}
+
+func (c *BasePriceRangeComponent) Quantity() decimal.Decimal {
+	quantity := decimal.NewFromInt(int64(1))
+	if c.quantityMultiplierFunc != nil {
+		quantity = quantity.Mul(c.quantityMultiplierFunc(c.resource))
+	}
+
+	timeUnitMultiplier := timeUnitSecs["month"].Div(timeUnitSecs[c.timeUnit])
+	resourceCount := decimal.NewFromInt(int64(c.resource.ResourceCount()))
+
+	return quantity.Mul(timeUnitMultiplier).Mul(resourceCount).Round(6)
+}
+
+func (c *BasePriceRangeComponent) SetQuantityMultiplierFunc(f func(resource Resource) decimal.Decimal) {
+	c.quantityMultiplierFunc = f
+}
+
+func (c *BasePriceRangeComponent) PriceRange() *PriceRange {
+	return c.priceRange
+}
+
+func (c *BasePriceRangeComponent) SetPriceRange(priceRange *PriceRange) {
+	c.priceRange = priceRange
+}
+
+func (c *BasePriceRangeComponent) HourlyCost() *PriceRange {
+
+	return c.priceRange
+}
+
 type BaseResource struct {
-	address         string
-	rawValues       map[string]interface{}
-	hasCost         bool
-	references      map[string]Resource
-	resourceCount   int
-	subResources    []Resource
-	priceComponents []PriceComponent
+	address              string
+	rawValues            map[string]interface{}
+	hasCost              bool
+	references           map[string]Resource
+	resourceCount        int
+	subResources         []Resource
+	priceComponents      []PriceComponent
+	priceRangeComponents []PriceRangeComponent
 }
 
 func NewBaseResource(address string, rawValues map[string]interface{}, hasCost bool) *BaseResource {
@@ -200,8 +299,19 @@ func (r *BaseResource) PriceComponents() []PriceComponent {
 	return r.priceComponents
 }
 
+func (r *BaseResource) PriceRangeComponents() []PriceRangeComponent {
+	sort.Slice(r.priceRangeComponents, func(i, j int) bool {
+		return r.priceRangeComponents[i].Name() < r.priceRangeComponents[j].Name()
+	})
+	return r.priceRangeComponents
+}
+
 func (r *BaseResource) AddPriceComponent(priceComponent PriceComponent) {
 	r.priceComponents = append(r.priceComponents, priceComponent)
+}
+
+func (r *BaseResource) AddPriceRangeComponent(priceRangeComponent PriceRangeComponent) {
+	r.priceRangeComponents = append(r.priceRangeComponents, priceRangeComponent)
 }
 
 func (r *BaseResource) References() map[string]Resource {


### PR DESCRIPTION
Hey, I had a brief conversation with Ali about this...

I would be very helpful for our team to display calculation for Lambdas, however, it's a lot more nuanced than static resources. So I suggested a range estimation would be much more useful instead of not showing anything.

I tried giving this a little try with the code base as it is, sadly I didn't quite grasp all of the data modellings in time, you live and learn! But the concept can be very roughly proven with what I have below.

### Idea

Given the very basic defaults from TF about AWS lambdas using `aws_lambda_function` resource, for example, timeout and memory limit, you can estimate an upper bound on the number of requests possible within an hour. Same with GB/s costs.

Further, if the TF specifies any triggering mechanisms, for example, rate/schedule, it's possible to estimate the lower bounds of executions.

And this is all prior to using empirical data from CloudWatch, which can make this estimation process even more useful.

Of course, using lower and upper bounds is just the start, and this idea can be expanded into more glorious statistical wonders!

### Implementaiton

Given an example TF file with the following resource:

```terraform
resource "aws_lambda_function" "lambda" {
  ...
  # timeout default to 3 seconds
}
```

I can generate a table output with infracost like this:

![image](https://user-images.githubusercontent.com/905730/90945022-2dfc1800-e41a-11ea-9006-c7f001d46209.png)

Note: The quantity is screwed up and should be the number of possible requests in an hour, etc. Also the subtotal and total is not calculated. However, the important part is that the price change information is now given in a `MIN - MAX` format which allows me to make a decision/start a conversation about the new resources I'm adding.