### PR TITLE
Add initial work on integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 	rm -rf release/$(BINARY)*
 
 test:
-	go test ./... -v
+	go test ./... $(or $(ARGS), -v)
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -89,9 +89,14 @@ Run the code:
 make run ARGS="--tfdir <Terraform Dir>"
 ```
 
-Run tests:
+Run all tests:
 ```sh
 make test
+```
+
+Exclude integration tests:
+```sh
+make test ARGS="-v -short"
 ```
 
 Build:

--- a/internal/terraform/aws/ec2_instance_test.go
+++ b/internal/terraform/aws/ec2_instance_test.go
@@ -1,0 +1,108 @@
+package aws_test
+
+import (
+	"infracost/internal/testutil"
+	"infracost/pkg/costs"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shopspring/decimal"
+)
+
+func TestEc2InstanceIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+resource "aws_instance" "instance1" {
+	ami           = "fake_ami"
+	instance_type = "m3.medium"
+
+	root_block_device {
+		volume_size = 10
+	}
+
+	ebs_block_device {
+		device_name = "xvdf"
+		volume_size = 10
+	}
+
+	ebs_block_device {
+		device_name = "xvdg"
+		volume_type = "standard"
+		volume_size = 20
+	}
+
+	ebs_block_device {
+		device_name = "xvdh"
+		volume_type = "sc1"
+		volume_size = 30
+	}
+
+	ebs_block_device {
+		device_name = "xvdi"
+		volume_type = "io1"
+		volume_size = 40
+		iops        = 1000
+	}
+}`
+
+	resourceCostBreakdowns, err := testutil.RunTFCostBreakdown(tf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedPriceHashes := [][]string{
+		{"aws_instance.instance1", "instance hours (m3.medium)", "666e02bbe686f6950fd8a47a55e83a75-d2c98780d7b6e36641b521f1f8145c6f"},
+		{"aws_instance.instance1.root_block_device", "GB", "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f"},
+		{"aws_instance.instance1.ebs_block_device[0]", "GB", "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f"},
+		{"aws_instance.instance1.ebs_block_device[1]", "GB", "0ed17ed1777b7be91f5b5ce79916d8d8-ee3dd7e4624338037ca6fea0933a662f"},
+		{"aws_instance.instance1.ebs_block_device[2]", "GB", "3122df29367c2460c76537cccf0eadb5-ee3dd7e4624338037ca6fea0933a662f"},
+		{"aws_instance.instance1.ebs_block_device[3]", "GB", "99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f"},
+		{"aws_instance.instance1.ebs_block_device[3]", "IOPS", "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78"},
+	}
+
+	priceHashResults := testutil.ExtractPriceHashes(resourceCostBreakdowns)
+
+	if !cmp.Equal(priceHashResults, expectedPriceHashes, testutil.PriceHashResultSort) {
+		t.Error("got unexpected price hashes", priceHashResults)
+	}
+
+	var priceComponentCost *costs.PriceComponentCost
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1", "instance hours (m3.medium)")
+	if !cmp.Equal(priceComponentCost.HourlyCost, priceComponentCost.PriceComponent.Price()) {
+		t.Error("got unexpected cost", "aws_instance.instance1", "instance hours (m3.medium)")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.root_block_device", "GB")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(10)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.root_block_device", "GB")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.ebs_block_device[0]", "GB")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(10)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.ebs_block_device[0]", "GB")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.ebs_block_device[1]", "GB")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(20)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.ebs_block_device[1]", "GB")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.ebs_block_device[2]", "GB")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(30)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.ebs_block_device[2]", "GB")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.ebs_block_device[3]", "GB")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(40)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.ebs_block_device[3]", "GB")
+	}
+
+	priceComponentCost = testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_instance.instance1.ebs_block_device[3]", "IOPS")
+	if !cmp.Equal(priceComponentCost.MonthlyCost, priceComponentCost.PriceComponent.Price().Mul(decimal.NewFromInt(int64(1000)))) {
+		t.Error("got unexpected cost", "aws_instance.instance1.ebs_block_device[3]", "IOPS")
+	}
+}

--- a/internal/terraform/aws/elb.go
+++ b/internal/terraform/aws/elb.go
@@ -25,7 +25,7 @@ func NewElb(address string, region string, rawValues map[string]interface{}, isC
 			{Key: "usagetype", ValueRegex: strPtr("/LoadBalancerUsage/")},
 		},
 	}
-	hours := resource.NewBasePriceComponent("Hours", r, "hour", "hour", hoursProductFilter, nil)
+	hours := resource.NewBasePriceComponent("hours", r, "hour", "hour", hoursProductFilter, nil)
 	r.AddPriceComponent(hours)
 
 	return r

--- a/internal/terraform/aws/nat_gateway.go
+++ b/internal/terraform/aws/nat_gateway.go
@@ -16,7 +16,7 @@ func NewNatGateway(address string, region string, rawValues map[string]interface
 			{Key: "usagetype", ValueRegex: strPtr("/NatGateway-Hours/")},
 		},
 	}
-	hours := resource.NewBasePriceComponent("Hours", r, "hour", "hour", hoursProductFilter, nil)
+	hours := resource.NewBasePriceComponent("hours", r, "hour", "hour", hoursProductFilter, nil)
 	r.AddPriceComponent(hours)
 
 	return r

--- a/internal/terraform/aws/nat_gateway_test.go
+++ b/internal/terraform/aws/nat_gateway_test.go
@@ -1,0 +1,40 @@
+package aws_test
+
+import (
+	"infracost/internal/testutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNatGatewayIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+resource "aws_nat_gateway" "nat" {
+	allocation_id = "eip-12345678"
+	subnet_id     = "subnet-12345678"
+}`
+
+	resourceCostBreakdowns, err := testutil.RunTFCostBreakdown(tf)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedPriceHashes := [][]string{
+		{"aws_nat_gateway.nat", "hours", "6e137a9da0718f0ec80fb60866730ba9-d2c98780d7b6e36641b521f1f8145c6f"},
+	}
+
+	priceHashResults := testutil.ExtractPriceHashes(resourceCostBreakdowns)
+
+	if !cmp.Equal(priceHashResults, expectedPriceHashes, testutil.PriceHashResultSort) {
+		t.Error("got unexpected price hashes", priceHashResults)
+	}
+
+	priceComponentCost := testutil.PriceComponentCostFor(resourceCostBreakdowns, "aws_nat_gateway.nat", "hours")
+	if !cmp.Equal(priceComponentCost.HourlyCost, priceComponentCost.PriceComponent.Price()) {
+		t.Error("got unexpected cost", "aws_nat_gateway.nat", "hours")
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"fmt"
+	"infracost/pkg/config"
+	"infracost/pkg/costs"
+	"infracost/pkg/parsers/terraform"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+var tfPrefix = `
+provider "aws" {
+	region                      = "us-east-1"
+	s3_force_path_style         = true
+	skip_credentials_validation = true
+	skip_metadata_api_check     = true
+	skip_requesting_account_id  = true
+	access_key                  = "mock_access_key"
+	secret_key                  = "mock_secret_key"
+}
+`
+
+func RunTFCostBreakdown(resourceTf string) ([]costs.ResourceCostBreakdown, error) {
+	tf := fmt.Sprintf("%s\n%s", tfPrefix, resourceTf)
+
+	// Create temporary directory and output terraform code
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return []costs.ResourceCostBreakdown{}, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "main.tf"), []byte(tf), 0644)
+	if err != nil {
+		return []costs.ResourceCostBreakdown{}, err
+	}
+
+	planJSON, err := terraform.GeneratePlanJSON(tmpDir, "")
+	if err != nil {
+		return []costs.ResourceCostBreakdown{}, err
+	}
+
+	resources, err := terraform.ParsePlanJSON(planJSON)
+	if err != nil {
+		return []costs.ResourceCostBreakdown{}, err
+	}
+
+	q := costs.NewGraphQLQueryRunner(fmt.Sprintf("%s/graphql", config.Config.ApiUrl))
+	return costs.GenerateCostBreakdowns(q, resources)
+}
+
+var PriceHashResultSort = cmpopts.SortSlices(func(x, y []string) bool {
+	return fmt.Sprintf("%s %s", x[0], x[1]) < fmt.Sprintf("%s %s", y[0], y[1])
+})
+
+func ExtractPriceHashes(resourceCostBreakdowns []costs.ResourceCostBreakdown) [][]string {
+	priceHashes := [][]string{}
+
+	for _, resourceCostBreakdown := range resourceCostBreakdowns {
+		for _, priceComponentCost := range resourceCostBreakdown.PriceComponentCosts {
+			priceHashes = append(priceHashes, []string{resourceCostBreakdown.Resource.Address(), priceComponentCost.PriceComponent.Name(), priceComponentCost.PriceHash})
+		}
+
+		priceHashes = append(priceHashes, ExtractPriceHashes(resourceCostBreakdown.SubResourceCosts)...)
+	}
+
+	return priceHashes
+}
+
+func PriceComponentCostFor(resourceCostBreakdowns []costs.ResourceCostBreakdown, resourceAddress string, priceComponentName string) *costs.PriceComponentCost {
+	for _, resourceCostBreakdown := range resourceCostBreakdowns {
+		for _, priceComponentCost := range resourceCostBreakdown.PriceComponentCosts {
+			if resourceCostBreakdown.Resource.Address() == resourceAddress && priceComponentCost.PriceComponent.Name() == priceComponentName {
+				return &priceComponentCost
+			}
+		}
+
+		priceComponentCost := PriceComponentCostFor(resourceCostBreakdown.SubResourceCosts, resourceAddress, priceComponentName)
+		if priceComponentCost != nil {
+			return priceComponentCost
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"log"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -20,6 +22,11 @@ func (c *ConfigSpec) SetLogger(logger *logrus.Logger) {
 	c.Logger = logger
 }
 
+func rootDir() string {
+	_, b, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(b), "../..")
+}
+
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
@@ -35,8 +42,9 @@ func loadConfig() *ConfigSpec {
 
 	config.NoColor = false
 
-	if fileExists(".env.local") {
-		err = godotenv.Load(".env.local")
+	envLocalPath := filepath.Join(rootDir(), ".env.local")
+	if fileExists(envLocalPath) {
+		err = godotenv.Load(envLocalPath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/costs/query.go
+++ b/pkg/costs/query.go
@@ -43,6 +43,7 @@ func (q *GraphQLQueryRunner) buildQuery(productFilter *resource.ProductFilter, p
 		query($productFilter: ProductFilter!, $priceFilter: PriceFilter) {
 			products(filter: $productFilter) {
 				prices(filter: $priceFilter) {
+					priceHash
 					USD
 				}
 			}

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -1,6 +1,7 @@
-package resource
+package resource_test
 
 import (
+	"infracost/pkg/resource"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,12 +10,12 @@ import (
 )
 
 func TestFlattenSubResources(t *testing.T) {
-	r1 := NewBaseResource("r1", map[string]interface{}{}, true)
-	r2 := NewBaseResource("r2", map[string]interface{}{}, true)
-	r3 := NewBaseResource("r3", map[string]interface{}{}, true)
-	r4 := NewBaseResource("r4", map[string]interface{}{}, true)
-	r5 := NewBaseResource("r5", map[string]interface{}{}, true)
-	r6 := NewBaseResource("r6", map[string]interface{}{}, true)
+	r1 := resource.NewBaseResource("r1", map[string]interface{}{}, true)
+	r2 := resource.NewBaseResource("r2", map[string]interface{}{}, true)
+	r3 := resource.NewBaseResource("r3", map[string]interface{}{}, true)
+	r4 := resource.NewBaseResource("r4", map[string]interface{}{}, true)
+	r5 := resource.NewBaseResource("r5", map[string]interface{}{}, true)
+	r6 := resource.NewBaseResource("r6", map[string]interface{}{}, true)
 
 	r1.AddSubResource(r2)
 	r1.AddSubResource(r3)
@@ -22,17 +23,17 @@ func TestFlattenSubResources(t *testing.T) {
 	r2.AddSubResource(r5)
 	r4.AddSubResource(r6)
 
-	result := FlattenSubResources(r1)
-	expected := []Resource{r2, r4, r6, r5, r3}
-	if !cmp.Equal(result, expected, cmp.AllowUnexported(BaseResource{})) {
+	result := resource.FlattenSubResources(r1)
+	expected := []resource.Resource{r2, r4, r6, r5, r3}
+	if !cmp.Equal(result, expected, cmp.AllowUnexported(resource.BaseResource{})) {
 		t.Error("did not flatten subresources correctly", result)
 	}
 }
 
 func TestBasePriceComponentQuantity(t *testing.T) {
-	r1 := NewBaseResource("r1", map[string]interface{}{}, true)
-	monthlyPc := NewBasePriceComponent("monthlyPc", r1, "unit", "month", nil, nil)
-	hourlyPc := NewBasePriceComponent("hourlyPc", r1, "unit", "hour", nil, nil)
+	r1 := resource.NewBaseResource("r1", map[string]interface{}{}, true)
+	monthlyPc := resource.NewBasePriceComponent("monthlyPc", r1, "unit", "month", nil, nil)
+	hourlyPc := resource.NewBasePriceComponent("hourlyPc", r1, "unit", "hour", nil, nil)
 
 	result := monthlyPc.Quantity()
 	if !cmp.Equal(result, decimal.NewFromInt(int64(1))) {
@@ -51,7 +52,7 @@ func TestBasePriceComponentQuantity(t *testing.T) {
 	}
 	r1.SetResourceCount(1)
 
-	hourlyPc.SetQuantityMultiplierFunc(func(resource Resource) decimal.Decimal {
+	hourlyPc.SetQuantityMultiplierFunc(func(resource resource.Resource) decimal.Decimal {
 		return decimal.NewFromInt(int64(3))
 	})
 	result = hourlyPc.Quantity()
@@ -61,9 +62,9 @@ func TestBasePriceComponentQuantity(t *testing.T) {
 }
 
 func TestBasePriceComponentHourlyCost(t *testing.T) {
-	r1 := NewBaseResource("r1", map[string]interface{}{}, true)
-	monthlyPc := NewBasePriceComponent("monthlyPc", r1, "unit", "month", nil, nil)
-	hourlyPc := NewBasePriceComponent("hourlyPc", r1, "unit", "hour", nil, nil)
+	r1 := resource.NewBaseResource("r1", map[string]interface{}{}, true)
+	monthlyPc := resource.NewBasePriceComponent("monthlyPc", r1, "unit", "month", nil, nil)
+	hourlyPc := resource.NewBasePriceComponent("hourlyPc", r1, "unit", "hour", nil, nil)
 
 	result := hourlyPc.HourlyCost()
 	if !cmp.Equal(result, decimal.Zero) {
@@ -71,7 +72,7 @@ func TestBasePriceComponentHourlyCost(t *testing.T) {
 	}
 
 	hourlyPc.SetPrice(decimal.NewFromFloat(float64(0.2)))
-	hourlyPc.SetQuantityMultiplierFunc(func(resource Resource) decimal.Decimal {
+	hourlyPc.SetQuantityMultiplierFunc(func(resource resource.Resource) decimal.Decimal {
 		return decimal.NewFromInt(int64(2))
 	})
 	result = hourlyPc.HourlyCost()
@@ -80,7 +81,7 @@ func TestBasePriceComponentHourlyCost(t *testing.T) {
 	}
 
 	monthlyPc.SetPrice(decimal.NewFromFloat(float64(7.3)))
-	monthlyPc.SetQuantityMultiplierFunc(func(resource Resource) decimal.Decimal {
+	monthlyPc.SetQuantityMultiplierFunc(func(resource resource.Resource) decimal.Decimal {
 		return decimal.NewFromInt(int64(4))
 	})
 	result = monthlyPc.HourlyCost()
@@ -90,35 +91,35 @@ func TestBasePriceComponentHourlyCost(t *testing.T) {
 }
 
 func TestBestResourceSubResources(t *testing.T) {
-	r1 := NewBaseResource("r1", map[string]interface{}{}, true)
-	r2 := NewBaseResource("charlie", map[string]interface{}{}, true)
-	r3 := NewBaseResource("alpha", map[string]interface{}{}, true)
-	r4 := NewBaseResource("bravo", map[string]interface{}{}, true)
+	r1 := resource.NewBaseResource("r1", map[string]interface{}{}, true)
+	r2 := resource.NewBaseResource("charlie", map[string]interface{}{}, true)
+	r3 := resource.NewBaseResource("alpha", map[string]interface{}{}, true)
+	r4 := resource.NewBaseResource("bravo", map[string]interface{}{}, true)
 
 	r1.AddSubResource(r2)
 	r1.AddSubResource(r3)
 	r1.AddSubResource(r4)
 
 	result := r1.SubResources()
-	expected := []Resource{r3, r4, r2}
-	if !cmp.Equal(result, expected, cmp.AllowUnexported(BaseResource{})) {
+	expected := []resource.Resource{r3, r4, r2}
+	if !cmp.Equal(result, expected, cmp.AllowUnexported(resource.BaseResource{})) {
 		t.Error("did not sort the subresources correctly", result)
 	}
 }
 
 func TestBestResourcePriceComponents(t *testing.T) {
-	r1 := NewBaseResource("r1", map[string]interface{}{}, true)
-	pc1 := NewBasePriceComponent("charlie", r1, "unit", "month", nil, nil)
-	pc2 := NewBasePriceComponent("alpha", r1, "unit", "month", nil, nil)
-	pc3 := NewBasePriceComponent("bravo", r1, "unit", "month", nil, nil)
+	r1 := resource.NewBaseResource("r1", map[string]interface{}{}, true)
+	pc1 := resource.NewBasePriceComponent("charlie", r1, "unit", "month", nil, nil)
+	pc2 := resource.NewBasePriceComponent("alpha", r1, "unit", "month", nil, nil)
+	pc3 := resource.NewBasePriceComponent("bravo", r1, "unit", "month", nil, nil)
 
 	r1.AddPriceComponent(pc1)
 	r1.AddPriceComponent(pc2)
 	r1.AddPriceComponent(pc3)
 
 	result := r1.PriceComponents()
-	expected := []PriceComponent{pc2, pc3, pc1}
-	if !cmp.Equal(result, expected, cmp.AllowUnexported(BaseResource{}, BasePriceComponent{}), cmpopts.IgnoreFields(BasePriceComponent{}, "resource")) {
+	expected := []resource.PriceComponent{pc2, pc3, pc1}
+	if !cmp.Equal(result, expected, cmp.AllowUnexported(resource.BaseResource{}, resource.BasePriceComponent{}), cmpopts.IgnoreFields(resource.BasePriceComponent{}, "resource")) {
 		t.Error("did not sort the price component correctly", result)
 	}
 }


### PR DESCRIPTION
We use the price hashes returned from the pricing API to validate we are mapping the correct prices. This means if the price changes, the tests won't break.

Currently only tests for `aws_nat_gateway` and `aws_instance` have been added.