### PR TITLE
Change createResource logic to registry based

### DIFF
--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -1,0 +1,8 @@
+package aws
+
+import "infracost/pkg/schema"
+
+var ResourceRegistry map[string]schema.ResourceFunc = map[string]schema.ResourceFunc{
+	"aws_instance":    AwsInstance,
+	"aws_nat_gateway": AwsNatGateway,
+}

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -6,18 +6,15 @@ import (
 	"regexp"
 	"strings"
 
-	"infracost/internal/providers/terraform/aws"
 	"infracost/pkg/schema"
 
 	"github.com/tidwall/gjson"
 )
 
 func createResource(resourceData *schema.ResourceData) *schema.Resource {
-	switch resourceData.Type {
-	case "aws_instance":
-		return aws.AwsInstance(resourceData)
-	case "aws_nat_gateway":
-		return aws.AwsNatGateway(resourceData)
+	resourceRegistry := getResourceRegistry()
+	if rFunc, ok := (*resourceRegistry)[resourceData.Type]; ok {
+		return rFunc(resourceData)
 	}
 	return nil
 }

--- a/internal/providers/terraform/resource_registry.go
+++ b/internal/providers/terraform/resource_registry.go
@@ -1,0 +1,28 @@
+package terraform
+
+import (
+	"infracost/internal/providers/terraform/aws"
+	"infracost/pkg/schema"
+	"sync"
+)
+
+type resourceRegistrySingleton map[string]schema.ResourceFunc
+
+var (
+	resourceRegistry resourceRegistrySingleton
+	once             sync.Once
+)
+
+func getResourceRegistry() *resourceRegistrySingleton {
+	once.Do(func() {
+		resourceRegistry = make(resourceRegistrySingleton)
+		// Merge all resource registries
+
+		// AWS
+		for k, v := range aws.ResourceRegistry {
+			resourceRegistry[k] = v
+		}
+
+	})
+	return &resourceRegistry
+}

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -6,6 +6,8 @@ import (
 
 var hourToMonthMultiplier = decimal.NewFromInt(730)
 
+type ResourceFunc func(*ResourceData) *Resource
+
 type Resource struct {
 	Name           string
 	SubResources   []*Resource


### PR DESCRIPTION
So I designed a kind of registry object in the way that:
* Each cloud provider has its own registry so it reduces the cost of conflicts
* Reduce the amount of switch-case duplicate codes

However, because of the Golang limitations it's not possible to have such kind of code:
```
func AwsInstance(d *schema.ResourceData) *schema.Resource {
...
}

terraform.AddResourceType("aws_instance", AwsInstance)
```
And that's because you can't have non-declrative statements in the root of files.